### PR TITLE
Add 422 status code

### DIFF
--- a/Response.php
+++ b/Response.php
@@ -91,6 +91,7 @@ class Response
         416 => 'Requested Range Not Satisfiable',
         417 => 'Expectation Failed',
         418 => 'I\'m a teapot',
+        422 => 'Unprocessable Entity',
         500 => 'Internal Server Error',
         501 => 'Not Implemented',
         502 => 'Bad Gateway',


### PR DESCRIPTION
Native HTTP doesn't have a good status code to represent validation failures in a request body. The closest you can get is using 400 Bad Request, but that should only be returned when the request body is malformed (i.e. incorrect syntax). Rails uses 422 Unprocessable Entity in those cases, which has been added to HTTP through a WebDAV extension. I prefer to do this in my PHP code as well, as the description matches the use case mentioned above perfectly.

> **422 Unprocessable Entity (WebDAV) (RFC 4918)**
> The request was well-formed but was unable to be followed due to semantic errors.
