### PR TITLE
Use Memcache::replace() first instead of Memcache::set():

### DIFF
--- a/Session/Storage/Handler/MemcacheSessionHandler.php
+++ b/Session/Storage/Handler/MemcacheSessionHandler.php
@@ -117,7 +117,10 @@ class MemcacheSessionHandler implements \SessionHandlerInterface
      */
     public function write($sessionId, $data)
     {
-        return $this->memcache->set($this->prefix.$sessionId, $data, 0, $this->memcacheOptions['expiretime']);
+        if (!$this->memcache->replace($this->prefix.$sessionId, $data, 0, $this->memcacheOptions['expiretime'])) {
+            return $this->memcache->set($this->prefix.$sessionId, $data, 0, $this->memcacheOptions['expiretime']);
+        }
+        return true;
     }
 
     /**


### PR DESCRIPTION
Using `Memcache::set()` in a multi-server environment can yield unexpected results:
http://docs.php.net/manual/en/memcache.replace.php#100023

It's best to attempt `replace()` first and only use `set()` if the key does not exist.
