### PR TITLE
Add earlier PHP output buffers flush in Response::send()

### DIFF
--- a/Response.php
+++ b/Response.php
@@ -299,6 +299,11 @@ class Response
 
         if (function_exists('fastcgi_finish_request')) {
             fastcgi_finish_request();
+        } else {
+            while (O < ob_get_level()) {
+                ob_end_flush();
+            }
+            flush();
         }
 
         return $this;


### PR DESCRIPTION
In the Response::send() method you are calling the fastcgi_finish_request() in case it exists. This will provide a respectful performance boost when you have significant work being done by listeners acting on kernel terminal events; Sadly you are forgetting people that don't use FPM doing this.

The performance boost for a Vanilla PHP is not much: flushing earlier potentially helps higher layers such as the HTTPd or potential other cache layers: the sooner their buffer gets filled, the sooner they release information to the browser, even if the output buffer is still open. The explicit flush() is supposed to do exactly this.
