### PR TITLE
MongoBinData constructor should be now called with "type" parameter

### DIFF
--- a/Session/Storage/Handler/MongoDbSessionHandler.php
+++ b/Session/Storage/Handler/MongoDbSessionHandler.php
@@ -104,7 +104,7 @@ class MongoDbSessionHandler implements \SessionHandlerInterface
     {
         $data = array(
             $this->options['id_field']   => $sessionId,
-            $this->options['data_field'] => new \MongoBinData($data),
+            $this->options['data_field'] => new \MongoBinData($data, 0x02),
             $this->options['time_field'] => new \MongoTimestamp()
         );
 


### PR DESCRIPTION
From mongo driver version 1.2.11 E_DEPRECATED is emitted when the 2nd argument (type) is not used for MongoBinData constructor. At the moment the default value is 0x02 ("byte array").

See: http://php.net/manual/en/mongobindata.construct.php
