### PR TITLE
[NamespacedAttributeBag][HttpFoundation] Fixed bug to remove nonexistent element

### DIFF
--- a/Session/Attribute/NamespacedAttributeBag.php
+++ b/Session/Attribute/NamespacedAttributeBag.php
@@ -84,7 +84,7 @@ class NamespacedAttributeBag extends AttributeBag
     public function remove($name)
     {
         $retval = null;
-        $attributes = & $this->resolveAttributePath($name);
+        $attributes = & $this->resolveAttributePath($name, true);
         $name = $this->resolveKey($name);
         if (array_key_exists($name, $attributes)) {
             $retval = $attributes[$name];

--- a/Tests/Session/Attribute/NamespacedAttributeBagTest.php
+++ b/Tests/Session/Attribute/NamespacedAttributeBagTest.php
@@ -141,6 +141,8 @@ class NamespacedAttributeBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('drak', $this->bag->get('user.login'));
         $this->bag->remove('user.login');
         $this->assertNull($this->bag->get('user.login'));
+
+        $this->assertNull($this->bag->remove('None/nonexistent'));
     }
 
     public function testClear()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | -- |
| License | MIT |
| Doc PR | -- |

Fixed a bug in NamespacedAttributeBag causing a Warning exception
by array_key_exists while try to remove noneexistent namespaced element.
The array_key_exists got a null in $attributes argument instead
empty array.
- Updated Syntax of remove method
- Added test for check remove unexistent element
