### PR TITLE
Update Request.php

### DIFF
--- a/Request.php
+++ b/Request.php
@@ -1835,7 +1835,8 @@ class Request
         }
 
         $basename = basename($baseUrl);
-        if (empty($basename) || !strpos(rawurldecode($truncatedRequestUri), $basename)) {
+        $baseUrlPos = strpos(rawurldecode($truncatedRequestUri), $baseUrl);
+        if (empty($basename) || $baseUrlPos === false || $baseUrlPos !== 0) {
             // no match whatsoever; set it blank
             return '';
         }


### PR DESCRIPTION
This check should look for $baseUrl and not $basename to assure there is the trailing slash.
It should also ignore the name of the app file somewhere in the route.

Example:
App File: mobile.php
$baseUrl: /mobile.php
Route: /a-route/containing/mobile.php

Later checks in the matcher will think there is the baseUrl prefixed and fail (not find the matching route)