### PR TITLE
Output buffers must be properly flushed

### DIFF
--- a/Response.php
+++ b/Response.php
@@ -1253,6 +1253,7 @@ class Response
         ) {
             if ($flush) {
                 ob_end_flush();
+                flush();
             } else {
                 ob_end_clean();
             }


### PR DESCRIPTION
Output buffers must be properly flushed so the following example could work as expected.
/**
* Example
*/
// Creates new response object
$response = new Response(
    'Not found!',
    404,
    array('Content-Type' => 'text/html')
);
// Adds HTTP headers required to close the connection
$response->headers->add(
        array(
            'Connection' => 'close',
            'Content-Length' => strlen($response->getContent()),
        )
    );
// Sends HTTP response
$response->send();