### PR TITLE
Cache a parsed Request in static property

### DIFF
--- a/Request.php
+++ b/Request.php
@@ -80,6 +80,11 @@ class Request
     );
 
     protected static $httpMethodParameterOverride = false;
+    
+    /**
+     * @var \Symfony\Component\HttpFoundation\ParameterBag
+     */
+    protected static $parsedRequest = null;
 
     /**
      * Custom parameters.
@@ -299,16 +304,21 @@ class Request
             }
         }
 
-        $request = self::createRequestFromFactory($_GET, $_POST, array(), $_COOKIE, $_FILES, $server);
+        if(self::$parsedRequest === null)
+        {
+            $request = self::createRequestFromFactory($_GET, $_POST, array(), $_COOKIE, $_FILES, $server);
 
-        if (0 === strpos($request->headers->get('CONTENT_TYPE'), 'application/x-www-form-urlencoded')
-            && in_array(strtoupper($request->server->get('REQUEST_METHOD', 'GET')), array('PUT', 'DELETE', 'PATCH'))
-        ) {
-            parse_str($request->getContent(), $data);
-            $request->request = new ParameterBag($data);
+            if (0 === strpos($request->headers->get('CONTENT_TYPE'), 'application/x-www-form-urlencoded')
+                && in_array(strtoupper($request->server->get('REQUEST_METHOD', 'GET')), array('PUT', 'DELETE', 'PATCH'))
+            ) {
+                parse_str($request->getContent(), $data);
+                $request->request = new ParameterBag($data);
+            }
+
+            self::$parsedRequest = $request;
         }
 
-        return $request;
+        return self::$parsedRequest;
     }
 
     /**


### PR DESCRIPTION
Normally you wouldn't call Request::createFromGlobals() more than once, but sometimes it happens due to bad design in legacy code. Instead of processing the same request data on every call, the parsed result should be stored in a static property on the first call and return the cached data on subsequent calls.