### PR TITLE
Adjust $requestUri in case of Apache and mod_rewrite.

### DIFF
--- a/Request.php
+++ b/Request.php
@@ -1790,7 +1790,11 @@ class Request
             $requestUri = $this->server->get('UNENCODED_URL');
             $this->server->remove('UNENCODED_URL');
             $this->server->remove('IIS_WasUrlRewritten');
-        } elseif ($this->server->has('REQUEST_URI')) {
+        } elseif ($this->server->has('REDIRECT_URL')) {
+            // Apache with mod_rewrite.
+            $requestUri = $this->server->get('REDIRECT_URL');
+            $this->server->remove('REDIRECT_URL');
+	} elseif ($this->server->has('REQUEST_URI')) {
             $requestUri = $this->server->get('REQUEST_URI');
             // HTTP proxy reqs setup request URI with scheme and host [and port] + the URL path, only use URL path
             $schemeAndHttpHost = $this->getSchemeAndHttpHost();


### PR DESCRIPTION
When apache does internal redirect with mod_rewrite it stores proper URI in server variable REDIRECT_URL.

Patch to adjust creating $requestUri based on this variable.