### PR TITLE
$headers[PHP_AUTH_PW] error with public clients

### DIFF
--- a/ServerBag.php
+++ b/ServerBag.php
@@ -92,6 +92,9 @@ class ServerBag extends ParameterBag
 
         // PHP_AUTH_USER/PHP_AUTH_PW
         if (isset($headers['PHP_AUTH_USER'])) {
+            if (!isset($headers['PHP_AUTH_PW'])) {
+                $headers['PHP_AUTH_PW'] = '';
+            }
             $headers['AUTHORIZATION'] = 'Basic '.base64_encode($headers['PHP_AUTH_USER'].':'.$headers['PHP_AUTH_PW']);
         } elseif (isset($headers['PHP_AUTH_DIGEST'])) {
             $headers['AUTHORIZATION'] = $headers['PHP_AUTH_DIGEST'];


### PR DESCRIPTION
set $headers[PHP_AUTH_PW] = "" if !isset($headers[PHP_AUTH_PW] as with password grant_type for oauth2 public workflow

Encountered this issue while implementing user_credential workflow using oauth2-server-php library in Laravel framework.  

http://bshaffer.github.io/oauth2-server-php-docs/grant-types/user-credentials/

Am unable to submit header key PHP_AUTH_PW with no value.

Error:
exception 'ErrorException' with message 'Undefined index: PHP_AUTH_PW' in /oauth/vendor/symfony/http-foundation/ServerBag.php:98
