### PR TITLE
'Getter method for test property of UploadedFile class'

### DIFF
--- a/File/UploadedFile.php
+++ b/File/UploadedFile.php
@@ -192,6 +192,16 @@ class UploadedFile extends File
     }
 
     /**
+     * Returns whether the test mode is activated.
+     *
+     * @return bool True if test mode is activated.
+     */
+    public function getTest()
+    {
+        return $this->test;
+    }
+
+    /**
      * Returns whether the file was uploaded successfully.
      *
      * @return bool True if the file has been uploaded with HTTP and no error occurred.

--- a/Tests/File/UploadedFileTest.php
+++ b/Tests/File/UploadedFileTest.php
@@ -128,6 +128,20 @@ class UploadedFileTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('gif', $file->getClientOriginalExtension());
     }
 
+    public function testGetTest()
+    {
+        $file = new UploadedFile(
+            __DIR__.'/Fixtures/test.gif',
+            'original.gif',
+            'image/gif',
+            filesize(__DIR__.'/Fixtures/test.gif'),
+            null,
+            true
+        );
+
+        $this->assertEquals(true, $file->getTest());
+    }
+
     /**
      * @expectedException \Symfony\Component\HttpFoundation\File\Exception\FileException
      */


### PR DESCRIPTION
Would be great to be able to get test value. Some other frameworks using this component omit this field which makes it problematic e.g https://github.com/laravel/framework/blob/5.2/src/Illuminate/Http/UploadedFile.php#L72 here test property falls to default (false) value. I've created workaround and created PR https://github.com/laravel/framework/pull/13656/files but it would be much cleaner with getTest() method.
