### PR TITLE
Cookie expiry time should be an integer. Throws exception in php7 if …

### DIFF
--- a/Cookie.php
+++ b/Cookie.php
@@ -163,7 +163,7 @@ class Cookie
      */
     public function getExpiresTime()
     {
-        return $this->expire;
+        return (int) $this->expire;
     }
 
     /**


### PR DESCRIPTION
Cookie expiry time should be an integer. Throws exception in php7 if not properly type casted
