### PR TITLE
Cache ipCheck

### DIFF
--- a/Request.php
+++ b/Request.php
@@ -198,7 +198,12 @@ class Request
      * @var string
      */
     protected $defaultLocale = 'en';
-
+    
+    /**
+     * @var boolean
+     */
+    protected $validTrustedProxyIP;
+    
     /**
      * @var array
      */
@@ -1949,7 +1954,15 @@ class Request
      */
     public function isFromTrustedProxy()
     {
-        return self::$trustedProxies && IpUtils::checkIp($this->server->get('REMOTE_ADDR'), self::$trustedProxies);
+        if (!self::$trustedProxies) {
+            return false;
+        }
+
+        if (!isset($this->validTrustedProxyIP)) {
+            $this->validTrustedProxyIP = IpUtils::checkIp($this->server->get('REMOTE_ADDR'), self::$trustedProxies);
+        }
+
+        return $this->validTrustedProxyIP;
     }
 
     private function normalizeAndFilterClientIps(array $clientIps, $ip)


### PR DESCRIPTION
In our app we use trusted proxies. Using Blackfire we found `IpUtils::checkIp` was being called 454 times taking 3.15ms. 
Caching the result saves those 3ms.
