### PR TITLE
Request.php hardcodes top element of mimetype as result for method call.

### DIFF
--- a/Request.php
+++ b/Request.php
@@ -1332,8 +1332,20 @@ class Request
             static::initializeFormats();
         }
 
-        return isset(static::$formats[$format]) ? static::$formats[$format][0] : null;
+        if (isset(static::$formats[$format])) {
+            //Api versions change over time....let's return the one being requested instead of always the top one.
+            if ($this->headers->get('Accept') && in_array($this->headers->get('Accept'), static::$formats[$format])) {
+                return $this->headers->get('Accept');
+            }
+
+            //Default to returning the top one if not found.
+            return static::$formats[$format][0];
+        }
+
+        //Return null otherwise.
+        return null;
     }
+
 
     /**
      * Gets the mime types associated with the format.


### PR DESCRIPTION
When using this along with FOSRestBundle and JMSSerializer doing API versioning, hardcoding the top media type causes the automatic selection of the appropriate mimetype to not work.

Example:

```yml

fos_rest:
    param_fetcher_listener: true
    body_listener: true
    format_listener:
        rules:
            - { path: ^/, priorities: [ 'html', 'json', 'application/javascript', 'text/css', '*/*'], fallback_format: html, prefer_extension: true }
    body_converter:
        enabled: true
        validate: true
    view:
        mime_types:
            json:
              - 'application/json'
              - 'application/json;version=1.0'
              - 'application/json;version=1.1'
        view_response_listener: 'force'
        formats:
            xml:  false
            json: true
        templating_formats:
            html: true
    exception:
        codes:
            'Symfony\Component\Routing\Exception\ResourceNotFoundException': 404
            'Doctrine\ORM\OptimisticLockException': HTTP_CONFLICT
        messages:
            'Symfony\Component\Routing\Exception\ResourceNotFoundException': true
    allowed_methods_listener: true
    access_denied_listener:
        json: true
    versioning:
        enabled: true
        resolvers:
            query:
                enabled: false
            custom_header:
                enabled: false
            media_type:
                enabled: true
```

Submitting a request with the header:
```
Accept: application/json;version=1.1
```

Will always return `application/json` instead of `application/json;version=1.1`.