### PR TITLE
Fixing parameter name 'port' for HEADER_X_FORWARDED_PORT

### DIFF
--- a/Request.php
+++ b/Request.php
@@ -202,7 +202,7 @@ class Request
         self::HEADER_X_FORWARDED_FOR => 'for',
         self::HEADER_X_FORWARDED_HOST => 'host',
         self::HEADER_X_FORWARDED_PROTO => 'proto',
-        self::HEADER_X_FORWARDED_PORT => 'host',
+        self::HEADER_X_FORWARDED_PORT => 'port',
     );
 
     /**


### PR DESCRIPTION
@nicolas-grekas I suppose it is a copy-paste issue