### PR TITLE
Support code 300 (again) in isRedirect() or explain why not.

### DIFF
--- a/Response.php
+++ b/Response.php
@@ -1253,7 +1253,7 @@ class Response
      */
     public function isRedirect($location = null)
     {
-        return in_array($this->statusCode, array(201, 301, 302, 303, 307, 308)) && (null === $location ?: $location == $this->headers->get('Location'));
+        return in_array($this->statusCode, array(201, 300, 301, 302, 303, 307, 308)) && (null === $location ?: $location == $this->headers->get('Location'));
     }
 
     /**


### PR DESCRIPTION
Added 300 code to array of valid redirections in isRedirect().  
This remains consistent with deprecated isRedirection() which checked >= 300.

Not supporting 300 has effects on downstream projects 
drupal/redirect : https://www.drupal.org/node/2920454

If there is a good reason for removing support for 300, perhaps it would be a good time to document that.

Thanks!
