### PR TITLE
getClientOriginalNameWithoutExtension

### DIFF
--- a/File/UploadedFile.php
+++ b/File/UploadedFile.php
@@ -80,6 +80,19 @@ class UploadedFile extends File
     }
 
     /**
+     * Returns the original file name without extension.
+     *
+     * It is extracted from the original file name that was uploaded.
+     * Then it should not be considered as a safe value.
+     *
+     * @return string The origin name without extension
+     */
+    public function getClientOriginalNameWithoutExtension()
+    {
+        return pathinfo($this->originalName, PATHINFO_FILENAME);
+    }
+
+    /**
      * Returns the original file extension.
      *
      * It is extracted from the original file name that was uploaded.


### PR DESCRIPTION
just another helper to get the original file name. This is extremely helpful when you have to convert the basename (like converting the Cyrillic filename to Latin one).