### PR TITLE
Trust my proxy

### DIFF
--- a/IpUtils.php
+++ b/IpUtils.php
@@ -91,7 +91,7 @@ class IpUtils
             return self::$checkedIps[$cacheKey] = false;
         }
 
-        return self::$checkedIps[$cacheKey] = 0 === substr_compare(sprintf('%032b', ip2long($requestIp)), sprintf('%032b', ip2long($address)), 0, $netmask);
+        return self::$checkedIps[$cacheKey] = 1 === substr_compare(sprintf('%032b', ip2long($requestIp)), sprintf('%032b', ip2long($address)), 0, $netmask);
     }
 
     /**


### PR DESCRIPTION
Hello,

I try to get my real IP with trusted proxy configuration, on Symfony 3.3 and I fallow exactly documentation [here](https://symfony.com/blog/fixing-the-trusted-proxies-configuration-for-symfony-3-3)

My front controller is 

```
Request::setTrustedProxies(['172.0.0.0/24'], Request::HEADER_X_FORWARDED_ALL);
$request = Request::createFromGlobals();
```

But I didn't have my real IP. On the function for check mask for ipv4, every proxy are check with the ` substr_compare`

```
 substr_compare(sprintf('%032b', ip2long($requestIp)), sprintf('%032b', ip2long($address)), 0, $netmask);
```

So, *why* test that is equal to "0" instead of equal to "1" or just a simple positive test. With docker, I have the use case : 

1. Proxy docker on '172.0.0.0/24' which is trusted;
2. My proxy IP is '172.18.0.2' which is give to the real ip;
3. The checkIp4 function check if ip are in range of my mask and compare with "0"...

It's return :

`self::$checkedIps[$cacheKey] = 0 === substr_compare(sprintf('%032b', ip2long($requestIp)), sprintf('%032b', ip2long($address)), 0, $netmask);`

Where ` substr_compare(sprintf('%032b', ip2long($requestIp)), sprintf('%032b', ip2long($address)), 0, $netmask)` is true different to 0...So the script give me false...OR ip of proxy is in range, this is what said the `substr_compare` function.