### PR TITLE
Re-Implement missing Method

### DIFF
--- a/Session/Storage/Handler/MongoDbSessionHandler.php
+++ b/Session/Storage/Handler/MongoDbSessionHandler.php
@@ -163,6 +163,26 @@ class MongoDbSessionHandler extends AbstractSessionHandler
         return true;
     }
 
+     /**
+     * Create a date object using the class appropriate for the current mongo connection.
+     *
+     * Return an instance of a MongoDate or \MongoDB\BSON\UTCDateTime
+     *
+     * @param int $seconds An integer representing UTC seconds since Jan 1 1970.  Defaults to now.
+     *
+     * @return \MongoDate|\MongoDB\BSON\UTCDateTime
+     */
+    private function createDateTime($seconds = null)
+    {
+        if (null === $seconds) {
+            $seconds = time();
+        }
+        if ($this->mongo instanceof \MongoDB\Client) {
+            return new \MongoDB\BSON\UTCDateTime($seconds * 1000);
+        }
+        return new \MongoDate($seconds);
+    }
+    
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
we stumbled upon this issue during upgrading from 3.4 to 4.0 `createDateTime` is missing.

```
[05-Mar-2018 11:12:57 Europe/Vienna] PHP Fatal error:  Uncaught Error: Call to undefined method Symfony\Component\HttpFoundation\Session\Storage\Handler\MongoDbSessionHandler::createDateTime() in /opt/APP/vendor/symfony/http-foundation/Session/Storage/Handler/MongoDbSessionHandler.php:144
Stack trace:
#0 [internal function]: Symfony\Component\HttpFoundation\Session\Storage\Handler\MongoDbSessionHandler->updateTimestamp('96d983b59f8aef8...', 'user_obj|O:9:"k...')
#1 [internal function]: session_write_close()
#2 {main}
  thrown in /opt/APP/vendor/symfony/http-foundation/Session/Storage/Handler/MongoDbSessionHandler.php on line 144
```


the method is in the class in the 3.4 branches. but got somehow removed in 4.0
let me know if you need me to change anything.