### PR TITLE
Fix the updating of timestamp in the MemcachedSessionHandler

### DIFF
--- a/Session/Storage/Handler/MemcachedSessionHandler.php
+++ b/Session/Storage/Handler/MemcachedSessionHandler.php
@@ -80,7 +80,8 @@ class MemcachedSessionHandler extends AbstractSessionHandler
      */
     public function updateTimestamp($sessionId, $data)
     {
-        return $this->memcached->touch($this->prefix.$sessionId, time() + $this->ttl);
+        $this->memcached->touch($this->prefix.$sessionId, time() + $this->ttl);
+        return true;
     }
 
     /**


### PR DESCRIPTION
Conditions: Symfony 3.4, PHP7 and session handled over memcache.

Apparently `memcached::touch()` returns `false` on a subsequent call with the same parameters. Since `updateTimestamp` is used in `AbstractSessionHandler::write()`

```
public function write($sessionId, $data)
    {
        if (\PHP_VERSION_ID < 70000 && $this->prefetchData) {
            $readData = $this->prefetchData;
            $this->prefetchData = null;

            if ($readData === $data) {
                return $this->updateTimestamp($sessionId, $data);
            }
        }
...
```

the result is that `write` will return `false` **on a subsequent request within the same second**. The returning error is:

```
HP Fatal error:  Uncaught Symfony\Component\Debug\Exception\ContextErrorException: Warning: session_write_close(): Failed to write session data (user). Please verify that the current setting of session.save_path is correct (/var/lib/php/sessions) in Unknown:0
Stack trace:
#0 [internal function]: Symfony\Component\Debug\ErrorHandler->handleError(2, 'session_write_c...', 'Unknown', 0, NULL)
#1 [internal function]: session_write_close()
#2 {main}
  thrown in Unknown on line 0
```
(can be reproduced on `symfony/skeleton:3.4`)