### PR TITLE
Default deleteFileAfterSend to true

### DIFF
--- a/BinaryFileResponse.php
+++ b/BinaryFileResponse.php
@@ -350,7 +350,7 @@ class BinaryFileResponse extends Response
      *
      * @return $this
      */
-    public function deleteFileAfterSend($shouldDelete)
+    public function deleteFileAfterSend($shouldDelete = true)
     {
         $this->deleteFileAfterSend = $shouldDelete;
 


### PR DESCRIPTION
This should default to true when called since there is only one option for it.