### PR TITLE
Remove 201 from isRedirect

### DIFF
--- a/Response.php
+++ b/Response.php
@@ -1172,7 +1172,7 @@ class Response
      */
     public function isRedirect(string $location = null): bool
     {
-        return in_array($this->statusCode, array(201, 301, 302, 303, 307, 308)) && (null === $location ?: $location == $this->headers->get('Location'));
+        return in_array($this->statusCode, array(301, 302, 303, 307, 308)) && (null === $location ?: $location == $this->headers->get('Location'));
     }
 
     /**


### PR DESCRIPTION
Please forgive me if I'm wrong or misunderstanding, but should `201 Created` be considered a redirect? Although it is suggested to use the body of the response or the `Location` header to specify the location of the new resource, I wouldn't have thought it would be considered a redirect.