### PR TITLE
Fix Uncaught TypeError: substr_compare() parameter 4 should be integer

### DIFF
--- a/IpUtils.php
+++ b/IpUtils.php
@@ -78,7 +78,8 @@ class IpUtils
             if ('0' === $netmask) {
                 return self::$checkedIps[$cacheKey] = filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4);
             }
-
+            
+            $netmask = (int) $netmask;
             if ($netmask < 0 || $netmask > 32) {
                 return self::$checkedIps[$cacheKey] = false;
             }


### PR DESCRIPTION

On php7 and strict_types = 1 `substr_compare` expects 4th parameter to be integer, otherwise there is error "Fatal error: Uncaught TypeError: substr_compare() expects parameter 4 to be integer, string given"