### PR TITLE
Fix erasing cookies issue

### DIFF
--- a/Session/Storage/NativeSessionStorage.php
+++ b/Session/Storage/NativeSessionStorage.php
@@ -153,7 +153,7 @@ class NativeSessionStorage implements SessionStorageInterface
         if (null !== $this->emulateSameSite) {
             $originalCookie = SessionUtils::popSessionCookie(session_name(), session_id());
             if (null !== $originalCookie) {
-                header(sprintf('%s; SameSite=%s', $originalCookie, $this->emulateSameSite));
+                header(sprintf('%s; SameSite=%s', $originalCookie, $this->emulateSameSite), false);
             }
         }
 
@@ -225,7 +225,7 @@ class NativeSessionStorage implements SessionStorageInterface
         if (null !== $this->emulateSameSite) {
             $originalCookie = SessionUtils::popSessionCookie(session_name(), session_id());
             if (null !== $originalCookie) {
-                header(sprintf('%s; SameSite=%s', $originalCookie, $this->emulateSameSite));
+                header(sprintf('%s; SameSite=%s', $originalCookie, $this->emulateSameSite), false);
             }
         }
 


### PR DESCRIPTION
Prevent replacing existing cookies when starting or regenerating session on PHP < 7.3 with 'cookie_samesite' option.
See issue https://github.com/symfony/symfony/issues/29675