### PR TITLE
Fixed get wrong path info issue

### DIFF
--- a/Request.php
+++ b/Request.php
@@ -1864,6 +1864,10 @@ class Request
         if (null === ($baseUrl = $this->getBaseUrl())) {
             return $requestUri;
         }
+        
+        if (0 !== strpos($requestUri, $baseUrl)) {
+            return $requestUri;
+        }
 
         $pathInfo = substr($requestUri, \strlen($baseUrl));
         if (false === $pathInfo || '' === $pathInfo) {


### PR DESCRIPTION
When requestUri = 'xxx/yyy/index.php' and baseUrl = 'aaa/index.php', preparePathInfo() will be return '.php' not 'xxx/yyy/index.php'.