### PR TITLE
Reduce returntype of Response::getContent

### DIFF
--- a/Response.php
+++ b/Response.php
@@ -419,7 +419,7 @@ class Response
     /**
      * Gets the current response content.
      *
-     * @return string|false
+     * @return string
      */
     public function getContent()
     {


### PR DESCRIPTION
In the constructor and setContent() it is enforced this this is always a string.

This saves me a check in a few places to satisfy static analysis.