### PR TITLE
improve php doc

### DIFF
--- a/Request.php
+++ b/Request.php
@@ -184,7 +184,7 @@ class Request
     protected $format;
 
     /**
-     * @var SessionInterface
+     * @var SessionInterface|callable
      */
     protected $session;
 


### PR DESCRIPTION
hi,
Function name must be callable - a string, Closure or class implementing __invoke, currently \Symfony\Component\HttpFoundation\Session\SessionInterface or callable on phpdoc
![image](https://user-images.githubusercontent.com/11363999/97446347-8b917100-1943-11eb-8e1c-170fa838be30.png)
