### PR TITLE
chore(accessor): Use directly `has` method before get key

### DIFF
--- a/ParameterBag.php
+++ b/ParameterBag.php
@@ -87,7 +87,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
      */
     public function get(string $key, $default = null)
     {
-        return \array_key_exists($key, $this->parameters) ? $this->parameters[$key] : $default;
+        return $this->has($key) ? $this->parameters[$key] : $default;
     }
 
     /**


### PR DESCRIPTION
It seems that `get` check before if key exist in `parameters` bag, but not use the function create for this purpose.