### PR TITLE
Remove `array_reverse` function in x-forwarded-for ip address list

### DIFF
--- a/Request.php
+++ b/Request.php
@@ -2138,6 +2138,6 @@ class Request
         }
 
         // Now the IP chain contains only untrusted proxies and the client IP
-        return $clientIps ? array_reverse($clientIps) : [$firstTrustedIp];
+        return $clientIps ? $clientIps : [$firstTrustedIp];
     }
 }


### PR DESCRIPTION
Who suggest the "we should reverse x-forwarded-for ip addresses list" idea and who accepted this i don't know but this behavior is wrong. Client ip address is first one of x-forwarded-for ip address list and if there is a 1 or multiple gateway between client and server, gateway ip addresses are added last of array.

References:
- https://en.wikipedia.org/wiki/X-Forwarded-For
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For