### PR TITLE
Add a possibility to use litespeed_finish_request

### DIFF
--- a/Response.php
+++ b/Response.php
@@ -395,6 +395,8 @@ class Response
 
         if (\function_exists('fastcgi_finish_request')) {
             fastcgi_finish_request();
+        } elseif (\function_exists('litespeed_finish_request')) {
+            litespeed_finish_request();
         } elseif (!\in_array(\PHP_SAPI, ['cli', 'phpdbg'], true)) {
             static::closeOutputBuffers(0, true);
         }


### PR DESCRIPTION
Add a possibility to use `litespeed_finish_request` instead of `fastcgi_finish_request` if Litespeed is being used on the server.
 Litespeed currently disabled it due to some problems: https://github.com/php/php-src/commit/ccf051c317e606c2a4d9099c6e79a5c42bfdb298 so the alias for `fastcgi_finish_request` doesn't work.