### PR TITLE
Notice when HTTP_PHP_AUTH_USER passed without pass

### DIFF
--- a/ServerBag.php
+++ b/ServerBag.php
@@ -89,7 +89,7 @@ class ServerBag extends ParameterBag
 
         // PHP_AUTH_USER/PHP_AUTH_PW
         if (isset($headers['PHP_AUTH_USER'])) {
-            $headers['AUTHORIZATION'] = 'Basic '.base64_encode($headers['PHP_AUTH_USER'].':'.$headers['PHP_AUTH_PW']);
+            $headers['AUTHORIZATION'] = 'Basic '.base64_encode($headers['PHP_AUTH_USER'].':'.($headers['PHP_AUTH_PW'] ?? ''));
         } elseif (isset($headers['PHP_AUTH_DIGEST'])) {
             $headers['AUTHORIZATION'] = $headers['PHP_AUTH_DIGEST'];
         }


### PR DESCRIPTION
There is a chance to get notice when HTTP_PHP_AUTH_USER passed, but  HTTP_PHP_AUTH_PW is not