### PR TITLE
solved this error:

### DIFF
--- a/Request.php
+++ b/Request.php
@@ -208,7 +208,7 @@ class Request
     private ?string $preferredFormat = null;
     private bool $isHostValid = true;
     private bool $isForwardedValid = true;
-    private bool $isSafeContentPreferred;
+    private bool $isSafeContentPreferred = false;
 
     private static int $trustedHeaderSet = -1;
 


### PR DESCRIPTION
Typed property Symfony\Component\HttpFoundation\Request::$isSafeContentPreferred must not be accessed before initialization

set $isSafeContentPreferred = false;

Not sure if this option was preferred.