### PR TITLE
Only manipulate headers if not already sent

### DIFF
--- a/Session/SessionUtils.php
+++ b/Session/SessionUtils.php
@@ -49,9 +49,11 @@ final class SessionUtils
             return null;
         }
 
-        header_remove('Set-Cookie');
-        foreach ($otherCookies as $h) {
-            header($h, false);
+        if(!headers_sent()) {
+            header_remove('Set-Cookie');
+            foreach ($otherCookies as $h) {
+                header($h, false);
+            }
         }
 
         return $sessionCookie;


### PR DESCRIPTION
When you want to send headers before request finishes via
```php
class MyController  {
  public function myAction() {
      $response = new Response();
      $response->headers->set(
          'Content-Disposition',
          HeaderUtils::makeDisposition(
              HeaderUtils::DISPOSITION_ATTACHMENT,
              'file.txt
          )
      );
      
      $response->sendHeaders();
      ob_flush();
      flush();

      // do some work to populate response
      sleep(5); // this is only for demonstraton purposes

      return $response;
  }
}
```
I get a warning error 
> E_WARNING: Cannot modify header information - headers already sent in [Root folder]/vendor/symfony/http-foundation/Session/SessionUtils.php, line 54

With this PR the headers get only manipulated during `kernel.response` event if the headers have ot already been sent.