### PR TITLE
Add a missing possible returned type in comment

### DIFF
--- a/InputBag.php
+++ b/InputBag.php
@@ -25,7 +25,7 @@ final class InputBag extends ParameterBag
      *
      * @param string|int|float|bool|null $default The default value if the input key does not exist
      *
-     * @return string|int|float|bool|null
+     * @return string|int|float|bool|array|null
      */
     public function get(string $key, $default = null)
     {


### PR DESCRIPTION
Hello,

The method **http-foundation\InputBag.php > get(string $key, $default = null)** can return an array, but our IDE notice that it is not possible because the array type is missing in the comment of this function.

This PR is to add the missing array type in comment, to let our IDE know that **get** can return an array.

![image](https://user-images.githubusercontent.com/3934439/164257413-f4123650-8bd3-4265-86c4-7f8aec6b7a21.png)
