### PR TITLE
Automatic conversion of false to array is deprecated 

### DIFF
--- a/Request.php
+++ b/Request.php
@@ -340,6 +340,9 @@ class Request
         $server['REQUEST_METHOD'] = strtoupper($method);
 
         $components = parse_url($uri);
+        if (!$components) {
+            $components = [];
+        }
         if (isset($components['host'])) {
             $server['SERVER_NAME'] = $components['host'];
             $server['HTTP_HOST'] = $components['host'];

--- a/Tests/RequestTest.php
+++ b/Tests/RequestTest.php
@@ -263,6 +263,8 @@ class RequestTest extends TestCase
         // Fragment should not be included in the URI
         $request = Request::create('http://test.com/foo#bar');
         $this->assertEquals('http://test.com/foo', $request->getUri());
+
+        Request::create('/admin/reports/memcache/default/memcache:11211');
     }
 
     public function testCreateWithRequestUri()


### PR DESCRIPTION
See PHP RFC: Deprecate autovivification on false https://wiki.php.net/rfc/autovivification_false

Got the error on a Drupal instance with memcache module and memcache_admin sub module enabled.

PHP: 8.1.11
Drupal core: 9.5.0-rc1
memcache module : 2.5.0

Note: in the test: memcache:11211 (hostname: memcache, port: 11211) is the memcached instance  running with the docker image `bitnami/memcached:1.6.9`


Location: https://example.com/admin/reports/memcache/default/memcache%3A11211
Referrer: https://example.com/admin/reports/memcache/default
Message (partial):  

<img width="1182" alt="image" src="https://user-images.githubusercontent.com/5101533/206003125-2b0142f5-b980-4def-9af5-4337319d8098.png">

