### PR TITLE
Prevent browser bfcache by default

### DIFF
--- a/ResponseHeaderBag.php
+++ b/ResponseHeaderBag.php
@@ -244,7 +244,7 @@ class ResponseHeaderBag extends HeaderBag
             }
 
             // conservative by default
-            return 'no-cache, private';
+            return 'no-cache, no-store, private';
         }
 
         $header = $this->getCacheControlHeader();

--- a/ResponseHeaderBag.php
+++ b/ResponseHeaderBag.php
@@ -244,7 +244,7 @@ class ResponseHeaderBag extends HeaderBag
             }
 
             // conservative by default
-            return 'no-cache, no-store, private';
+            return 'no-store, private';
         }
 
         $header = $this->getCacheControlHeader();


### PR DESCRIPTION
Back / forward cache seems to be a fairly recent feature browsers seem to rollout.

More information can be found here: https://web.dev/bfcache.

Long story short, when a user for example login then logout from a given application, they could then hit the "Back" button from their browser and access the login page again with the credentials pre-filled as the page would be served from the `bfcache`. This could lead to security concerns, especially on shared devices where someone could inspect the page and retrieve some user credentials.

Currently, the sensible defaults for the HTTP cache headers seem to be `no-cache, private` in order to be conservative by default. A lot of applications currently rely on this to be the sensible default for their application too.

Replacing `no-cache` by `no-store` would prevent `bfcache` to kick in from any browser and could be considered as a more secure default.

> `no-cache` shows that returned responses can't be used for subsequent requests to the same URL before checking if server responses have changed. If a proper `ETag` (validation token) is present as a result, `no-cache` incurs a roundtrip in an effort to validate cached responses. Caches can however eliminate downloads if the resources haven't changed. In other words, web browsers might cache the assets but they have to check on every request if the assets have changed (304 response if nothing has changed).

> On the contrary, `no-store` is simpler. This is the case because it disallows browsers and all intermediate caches from storing any versions of returned responses, such as responses containing private/personal information or banking data. Every time users request this asset, requests are sent to the server. The assets are downloaded every time.

More information can be found here: https://www.keycdn.com/blog/http-cache-headers#no-cache-and-no-store

The purpose of this PR is to start the discussion rather than bringing a definite solution.