### PR TITLE
Fix file streaming after connection aborted

### DIFF
--- a/BinaryFileResponse.php
+++ b/BinaryFileResponse.php
@@ -310,7 +310,7 @@ class BinaryFileResponse extends Response
             }
 
             $length = $this->maxlen;
-            while ($length && !feof($file)) {
+            while ($length && !feof($file) && !connection_aborted()) {
                 $read = $length > $this->chunkSize || 0 > $length ? $this->chunkSize : $length;
 
                 if (false === $data = fread($file, $read)) {


### PR DESCRIPTION
After connection aborted, BinaryFileResponse.php will stream file until it's end.